### PR TITLE
EF flowables whose CAS do not match SRS EPA

### DIFF
--- a/fedelemflowlist/input/ChemicalsFlowablePrimaryContexts.csv
+++ b/fedelemflowlist/input/ChemicalsFlowablePrimaryContexts.csv
@@ -13252,3 +13252,180 @@ Uniconazole-P,Emission,Air
 Thorium dioxide,Emission,Air
 Thorium dioxide,Emission,Ground
 Thorium dioxide,Emission,Water
+Methyl 3-Methoxyacrylate,Emission,Water
+Methyl 3-Methoxyacrylate,Emission,Air
+Methyl 3-Methoxyacrylate,Emission,Ground
+Triisononanoin,Emission,Water
+Triisononanoin,Emission,Air
+Triisononanoin,Emission,Ground
+3-Formylbut-2-enyl acetate,Emission,Water
+3-Formylbut-2-enyl acetate,Emission,Air
+3-Formylbut-2-enyl acetate,Emission,Ground
+Bis(2-ethylhexyl) carbonate,Emission,Water
+Bis(2-ethylhexyl) carbonate,Emission,Air
+Bis(2-ethylhexyl) carbonate,Emission,Ground
+Ditetradecyl fumarate,Emission,Water
+Ditetradecyl fumarate,Emission,Air
+Ditetradecyl fumarate,Emission,Ground
+2-Methyl-1-heptanol,Emission,Water
+2-Methyl-1-heptanol,Emission,Air
+2-Methyl-1-heptanol,Emission,Ground
+Cyclohexylglycerin,Emission,Water
+Cyclohexylglycerin,Emission,Air
+Cyclohexylglycerin,Emission,Ground
+Cyclopropylacetylene,Emission,Water
+Cyclopropylacetylene,Emission,Air
+Cyclopropylacetylene,Emission,Ground
+3-O-Ethyl-L-ascorbic acid,Emission,Water
+3-O-Ethyl-L-ascorbic acid,Emission,Air
+3-O-Ethyl-L-ascorbic acid,Emission,Ground
+"methyl (1R,2S)-3-oxo-2-pentylcyclopentane-1-carboxylate",Emission,Water
+"methyl (1R,2S)-3-oxo-2-pentylcyclopentane-1-carboxylate",Emission,Air
+"methyl (1R,2S)-3-oxo-2-pentylcyclopentane-1-carboxylate",Emission,Ground
+1-Methylcyclohexanecarboxylic acid,Emission,Water
+1-Methylcyclohexanecarboxylic acid,Emission,Air
+1-Methylcyclohexanecarboxylic acid,Emission,Ground
+"Diethyl 1,2-cyclopentanedicarboxylate",Emission,Water
+"Diethyl 1,2-cyclopentanedicarboxylate",Emission,Air
+"Diethyl 1,2-cyclopentanedicarboxylate",Emission,Ground
+"2,2-Dimethyl-3-oxopropyl dodecanoate",Emission,Water
+"2,2-Dimethyl-3-oxopropyl dodecanoate",Emission,Air
+"2,2-Dimethyl-3-oxopropyl dodecanoate",Emission,Ground
+"2,4,7,9-Tetramethyldecane-4,7-diol",Emission,Water
+"2,4,7,9-Tetramethyldecane-4,7-diol",Emission,Air
+"2,4,7,9-Tetramethyldecane-4,7-diol",Emission,Ground
+(+)-Isobutyl D-lactate,Emission,Water
+(+)-Isobutyl D-lactate,Emission,Air
+(+)-Isobutyl D-lactate,Emission,Ground
+"4-Propyl-4'-vinyl-1,1'-bi(cyclohexane)",Emission,Water
+"4-Propyl-4'-vinyl-1,1'-bi(cyclohexane)",Emission,Air
+"4-Propyl-4'-vinyl-1,1'-bi(cyclohexane)",Emission,Ground
+"(1R, 4R, 5S) 4-Hydroxy-6,6-dimethyl-3-oxabicyclo(3.1.0)hexan-2-one",Emission,Water
+"(1R, 4R, 5S) 4-Hydroxy-6,6-dimethyl-3-oxabicyclo(3.1.0)hexan-2-one",Emission,Air
+"(1R, 4R, 5S) 4-Hydroxy-6,6-dimethyl-3-oxabicyclo(3.1.0)hexan-2-one",Emission,Ground
+Ethylene glycol diacetoacetate,Emission,Water
+Ethylene glycol diacetoacetate,Emission,Air
+Ethylene glycol diacetoacetate,Emission,Ground
+"3,5,5-Trimethylcyclohex-3-en-1-one",Emission,Water
+"3,5,5-Trimethylcyclohex-3-en-1-one",Emission,Air
+"3,5,5-Trimethylcyclohex-3-en-1-one",Emission,Ground
+Diethyl 2-(2-oxopropyl)succinate,Emission,Water
+Diethyl 2-(2-oxopropyl)succinate,Emission,Air
+Diethyl 2-(2-oxopropyl)succinate,Emission,Ground
+"6,8-Dimethylnona-3,5-dien-2-one",Emission,Water
+"6,8-Dimethylnona-3,5-dien-2-one",Emission,Air
+"6,8-Dimethylnona-3,5-dien-2-one",Emission,Ground
+2-Chloro-3-methyl-4-(methylsulfonyl)benzoic acid,Emission,Water
+2-Chloro-3-methyl-4-(methylsulfonyl)benzoic acid,Emission,Air
+2-Chloro-3-methyl-4-(methylsulfonyl)benzoic acid,Emission,Ground
+Allyl acetoacetate,Emission,Water
+Allyl acetoacetate,Emission,Air
+Allyl acetoacetate,Emission,Ground
+"3,3-Dimethyl-1-Butyne",Emission,Water
+"3,3-Dimethyl-1-Butyne",Emission,Air
+"3,3-Dimethyl-1-Butyne",Emission,Ground
+Propylheptyl caprylate,Emission,Water
+Propylheptyl caprylate,Emission,Air
+Propylheptyl caprylate,Emission,Ground
+Oleyl erucate,Emission,Water
+Oleyl erucate,Emission,Air
+Oleyl erucate,Emission,Ground
+"(trans,trans)-4-Pentyl-4'-vinyl-1,1'-bi(cyclohexane)",Emission,Water
+"(trans,trans)-4-Pentyl-4'-vinyl-1,1'-bi(cyclohexane)",Emission,Air
+"(trans,trans)-4-Pentyl-4'-vinyl-1,1'-bi(cyclohexane)",Emission,Ground
+Didodecyl fumarate,Emission,Water
+Didodecyl fumarate,Emission,Air
+Didodecyl fumarate,Emission,Ground
+"Propanoic acid, 2-hydroxy-, (1R,2S,5R)-5-methyl-2-(1-methylethyl)cyclohexyl ester, (2S)-",Emission,Water
+"Propanoic acid, 2-hydroxy-, (1R,2S,5R)-5-methyl-2-(1-methylethyl)cyclohexyl ester, (2S)-",Emission,Air
+"Propanoic acid, 2-hydroxy-, (1R,2S,5R)-5-methyl-2-(1-methylethyl)cyclohexyl ester, (2S)-",Emission,Ground
+"3,5-Dimethyl-1,2-dioxolane-3,5-diol",Emission,Water
+"3,5-Dimethyl-1,2-dioxolane-3,5-diol",Emission,Air
+"3,5-Dimethyl-1,2-dioxolane-3,5-diol",Emission,Ground
+(S)-(+)-3-Hydroxytetrahydrofuran,Emission,Water
+(S)-(+)-3-Hydroxytetrahydrofuran,Emission,Air
+(S)-(+)-3-Hydroxytetrahydrofuran,Emission,Ground
+5-(Methoxymethyl)-2-furaldehyde,Emission,Water
+5-(Methoxymethyl)-2-furaldehyde,Emission,Air
+5-(Methoxymethyl)-2-furaldehyde,Emission,Ground
+"Bis(7-methyloctyl) Cyclohexane-1,2-dicarboxylate",Emission,Water
+"Bis(7-methyloctyl) Cyclohexane-1,2-dicarboxylate",Emission,Air
+"Bis(7-methyloctyl) Cyclohexane-1,2-dicarboxylate",Emission,Ground
+"(trans,trans)-4-(p-Tolyl)-4'-vinyl-1,1'-bi(cyclohexane)",Emission,Water
+"(trans,trans)-4-(p-Tolyl)-4'-vinyl-1,1'-bi(cyclohexane)",Emission,Air
+"(trans,trans)-4-(p-Tolyl)-4'-vinyl-1,1'-bi(cyclohexane)",Emission,Ground
+Pentaerythrityl tetraheptanoate,Emission,Water
+Pentaerythrityl tetraheptanoate,Emission,Air
+Pentaerythrityl tetraheptanoate,Emission,Ground
+"4-Methyl-6-(2,4,4-trimethylpentyl)-2H-pyran-2-one",Emission,Water
+"4-Methyl-6-(2,4,4-trimethylpentyl)-2H-pyran-2-one",Emission,Air
+"4-Methyl-6-(2,4,4-trimethylpentyl)-2H-pyran-2-one",Emission,Ground
+"Bis(2-ethylhexyl) cyclohexane-1,4-dicarboxylate",Emission,Water
+"Bis(2-ethylhexyl) cyclohexane-1,4-dicarboxylate",Emission,Air
+"Bis(2-ethylhexyl) cyclohexane-1,4-dicarboxylate",Emission,Ground
+Isosorbide dicaprylate,Emission,Water
+Isosorbide dicaprylate,Emission,Air
+Isosorbide dicaprylate,Emission,Ground
+4-Butylresorcinol,Emission,Water
+4-Butylresorcinol,Emission,Air
+4-Butylresorcinol,Emission,Ground
+"3-(Hexyloxy)propane-1,2-diol",Emission,Water
+"3-(Hexyloxy)propane-1,2-diol",Emission,Air
+"3-(Hexyloxy)propane-1,2-diol",Emission,Ground
+Bis-propylheptyl carbonate,Emission,Water
+Bis-propylheptyl carbonate,Emission,Air
+Bis-propylheptyl carbonate,Emission,Ground
+Pentaerythrityl tetraisononanoate,Emission,Water
+Pentaerythrityl tetraisononanoate,Emission,Air
+Pentaerythrityl tetraisononanoate,Emission,Ground
+"2-Propenoic acid, 2-propylheptyl ester",Emission,Water
+"2-Propenoic acid, 2-propylheptyl ester",Emission,Air
+"2-Propenoic acid, 2-propylheptyl ester",Emission,Ground
+Isostearyl palmitate,Emission,Water
+Isostearyl palmitate,Emission,Air
+Isostearyl palmitate,Emission,Ground
+"(1S,5R)-6,8-dioxabicyclo[3.2.1]octan-4-one",Emission,Water
+"(1S,5R)-6,8-dioxabicyclo[3.2.1]octan-4-one",Emission,Air
+"(1S,5R)-6,8-dioxabicyclo[3.2.1]octan-4-one",Emission,Ground
+"2-Norpinene-2-ethanol, 6,6-dimethyl-, acetate",Emission,Water
+"2-Norpinene-2-ethanol, 6,6-dimethyl-, acetate",Emission,Air
+"2-Norpinene-2-ethanol, 6,6-dimethyl-, acetate",Emission,Ground
+"2-Ethyl-4-(2,2,3-trimethylcyclopent-3-en-1-yl)but-2-en-1-ol",Emission,Water
+"2-Ethyl-4-(2,2,3-trimethylcyclopent-3-en-1-yl)but-2-en-1-ol",Emission,Air
+"2-Ethyl-4-(2,2,3-trimethylcyclopent-3-en-1-yl)but-2-en-1-ol",Emission,Ground
+Glyceryl behenate,Emission,Water
+Glyceryl behenate,Emission,Air
+Glyceryl behenate,Emission,Ground
+Neononanoic acid,Emission,Water
+Neononanoic acid,Emission,Air
+Neononanoic acid,Emission,Ground
+1-(2-Ethyl-butyl)-cyclohexanecarboxylic acid,Emission,Water
+1-(2-Ethyl-butyl)-cyclohexanecarboxylic acid,Emission,Air
+1-(2-Ethyl-butyl)-cyclohexanecarboxylic acid,Emission,Ground
+Fenchyl acetate,Emission,Water
+Fenchyl acetate,Emission,Air
+Fenchyl acetate,Emission,Ground
+Allyl 2-hydroxyisobutyrate,Emission,Water
+Allyl 2-hydroxyisobutyrate,Emission,Air
+Allyl 2-hydroxyisobutyrate,Emission,Ground
+"1-(1,1-Dimethylethoxy)-2-methylpropane",Emission,Water
+"1-(1,1-Dimethylethoxy)-2-methylpropane",Emission,Air
+"1-(1,1-Dimethylethoxy)-2-methylpropane",Emission,Ground
+"Bis-ethoxydiglycol cyclohexane 1,4-dicarboxylate",Emission,Water
+"Bis-ethoxydiglycol cyclohexane 1,4-dicarboxylate",Emission,Air
+"Bis-ethoxydiglycol cyclohexane 1,4-dicarboxylate",Emission,Ground
+"3,3'-[Methylenebis(oxymethylene)]bisheptane",Emission,Water
+"3,3'-[Methylenebis(oxymethylene)]bisheptane",Emission,Air
+"3,3'-[Methylenebis(oxymethylene)]bisheptane",Emission,Ground
+2-O-alpha-D-Glucopyranosyl-L-ascorbic acid,Emission,Water
+2-O-alpha-D-Glucopyranosyl-L-ascorbic acid,Emission,Air
+2-O-alpha-D-Glucopyranosyl-L-ascorbic acid,Emission,Ground
+"2-Butene, 1,1,4,4-tetramethoxy-",Emission,Water
+"2-Butene, 1,1,4,4-tetramethoxy-",Emission,Air
+"2-Butene, 1,1,4,4-tetramethoxy-",Emission,Ground
+"Phenol, 4,5-dimethyl-2-(1-methylethyl)-",Emission,Water
+"Phenol, 4,5-dimethyl-2-(1-methylethyl)-",Emission,Air
+"Phenol, 4,5-dimethyl-2-(1-methylethyl)-",Emission,Ground
+"8-ethylidene-tetracyclo[4.4.0.1(2,5).1(7,10)]dodeca-3-ene",Emission,Water
+"8-ethylidene-tetracyclo[4.4.0.1(2,5).1(7,10)]dodeca-3-ene",Emission,Air
+"8-ethylidene-tetracyclo[4.4.0.1(2,5).1(7,10)]dodeca-3-ene",Emission,Ground

--- a/fedelemflowlist/input/ChemicalsFlowables.csv
+++ b/fedelemflowlist/input/ChemicalsFlowables.csv
@@ -5288,3 +5288,62 @@ Uniconazole-P,83657-17-4,C15H18ClN3O ,"1H-1,2,4-Triazole-1-ethanol, .beta.-[(4-
 "Z,E-3,13-Octadecadien-1-ol",73332-92-0,C18H34O,"3,13-Octadecadien-1-ol, (3Z,13E)-",kg,https://comptox.epa.gov/dashboard/dsstoxdb/results?search=DTXSID0034198,1
 "2,2,2-Trifluoroethyl acetate",406-95-1,C4H5F3O2,,kg,https://comptox.epa.gov/dashboard/dsstoxdb/results?search=DTXSID60193609,1
 Thorium dioxide,1314-20-4,O2Th,Thorium(IV) oxide,kg,https://sor.epa.gov/sor_internet/registry/substreg/searchandretrieve/substancesearch/search.do?details=displayDetails&selectedSubstanceId=42865,1
+Methyl 3-Methoxyacrylate,5788-17-0,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.101.217,1
+Triisononanoin,56554-53-1,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.054.762,1
+3-Formylbut-2-enyl acetate,26586-02-7,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.043.463,1
+Bis(2-ethylhexyl) carbonate,14858-73-2,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.035.372,1
+Ditetradecyl fumarate,10341-03-4,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.030.660,1
+2-Methyl-1-heptanol,60435-70-3,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.237.747,1
+Cyclohexylglycerin,10305-41-6,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.232.476,1
+Cyclopropylacetylene,6746-94-7,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.102.389,1
+3-O-Ethyl-L-ascorbic acid,86404-04-8,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.123.448,1
+"methyl (1R,2S)-3-oxo-2-pentylcyclopentane-1-carboxylate",1271488-66-4,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.149.419,1
+1-Methylcyclohexanecarboxylic acid,1123-25-7,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.013.066,1
+"Diethyl 1,2-cyclopentanedicarboxylate",90474-13-8,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.083.378,1
+"2,2-Dimethyl-3-oxopropyl dodecanoate",102985-93-3,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.104.889,1
+"2,4,7,9-Tetramethyldecane-4,7-diol",17913-76-7,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.104.261,1
+(+)-Isobutyl D-lactate,61597-96-4,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.100.924,1
+"4-Propyl-4'-vinyl-1,1'-bi(cyclohexane)",116020-44-1,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.129.286,1
+"(1R, 4R, 5S) 4-Hydroxy-6,6-dimethyl-3-oxabicyclo(3.1.0)hexan-2-one",73611-02-6,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.125.764,1
+Ethylene glycol diacetoacetate,5459-04-1,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.024.295,1
+"3,5,5-Trimethylcyclohex-3-en-1-one",471-01-2,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.006.760,1
+Diethyl 2-(2-oxopropyl)succinate,1187-74-2,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.101.304,1
+"6,8-Dimethylnona-3,5-dien-2-one",70214-76-5,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.067.657,1
+2-Chloro-3-methyl-4-(methylsulfonyl)benzoic acid,106904-09-0,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.109.138,1
+Allyl acetoacetate,1118-84-9,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.012.973,1
+"3,3-Dimethyl-1-Butyne",917-92-0,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.011.851,1
+Propylheptyl caprylate,868839-23-0,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.105.495,1
+Oleyl erucate,17673-56-2,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.037.852,1
+"(trans,trans)-4-Pentyl-4'-vinyl-1,1'-bi(cyclohexane)",129738-34-7,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.102.812,1
+Didodecyl fumarate,2402-58-6,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.017.529,1
+"Propanoic acid, 2-hydroxy-, (1R,2S,5R)-5-methyl-2-(1-methylethyl)cyclohexyl ester, (2S)-",61597-98-6,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.123.705,1
+"3,5-Dimethyl-1,2-dioxolane-3,5-diol",13784-51-5,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.034.021,1
+(S)-(+)-3-Hydroxytetrahydrofuran,86087-23-2,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.102.355,1
+5-(Methoxymethyl)-2-furaldehyde,1917-64-2,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.149.478,1
+"Bis(7-methyloctyl) Cyclohexane-1,2-dicarboxylate",166412-78-8,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.103.017,1
+"(trans,trans)-4-(p-Tolyl)-4'-vinyl-1,1'-bi(cyclohexane)",155041-85-3,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.103.628,1
+Pentaerythrityl tetraheptanoate,25811-35-2,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.042.967,1
+"4-Methyl-6-(2,4,4-trimethylpentyl)-2H-pyran-2-one",50650-75-4,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.113.342,1
+"Bis(2-ethylhexyl) cyclohexane-1,4-dicarboxylate",84731-70-4,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.076.180,1
+Isosorbide dicaprylate,64896-70-4,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.115.402,1
+4-Butylresorcinol,18979-61-8,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.126.948,1
+"3-(Hexyloxy)propane-1,2-diol",10305-38-1,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.128.410,1
+Bis-propylheptyl carbonate,1238449-42-7,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.155.435,1
+Pentaerythrityl tetraisononanoate,93803-89-5,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.089.379,1
+"2-Propenoic acid, 2-propylheptyl ester",149021-58-9,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.118.706,1
+Isostearyl palmitate,72576-80-8,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.069.723,1
+"(1S,5R)-6,8-dioxabicyclo[3.2.1]octan-4-one",53716-82-8,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.234.612,1
+"2-Norpinene-2-ethanol, 6,6-dimethyl-, acetate",35836-72-7,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.227.484,1
+"2-Ethyl-4-(2,2,3-trimethylcyclopent-3-en-1-yl)but-2-en-1-ol",106185-75-5,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.247.348,1
+Glyceryl behenate,77538-19-3,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.071.540,1
+Neononanoic acid,59354-78-8,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.056.088,1
+1-(2-Ethyl-butyl)-cyclohexanecarboxylic acid,381209-09-2,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.126.106,1
+Fenchyl acetate,4057-31-2,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.235.414,1
+Allyl 2-hydroxyisobutyrate,19444-21-4,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.223.824,1
+"1-(1,1-Dimethylethoxy)-2-methylpropane",33021-02-2,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.046.665,1
+"Bis-ethoxydiglycol cyclohexane 1,4-dicarboxylate",922165-31-9,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.124.471,1
+"3,3'-[Methylenebis(oxymethylene)]bisheptane",22174-70-5,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.040.726,1
+2-O-alpha-D-Glucopyranosyl-L-ascorbic acid,129499-78-1,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.102.444,1
+"2-Butene, 1,1,4,4-tetramethoxy-",5370-08-1,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.139.336,1
+"Phenol, 4,5-dimethyl-2-(1-methylethyl)-",35786-94-8,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.214.943,1
+"8-ethylidene-tetracyclo[4.4.0.1(2,5).1(7,10)]dodeca-3-ene",38233-76-0,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.149.349,1

--- a/fedelemflowlist/input/GroupsFlowablePrimaryContexts.csv
+++ b/fedelemflowlist/input/GroupsFlowablePrimaryContexts.csv
@@ -556,3 +556,24 @@ C12-14-Alkyldimethyl(ethylbenzyl) ammonium chlorides,Emission,Ground
 C12-18-Dialkylmethylbenzyl ammonium chlorides,Emission,Ground
 C8-18 and C18-Unsaturated fatty acids ammonium salts,Emission,Ground
 Capsicum oleoresins,Emission,Ground
+"Fatty acids, C8-10, C12-18-alkyl esters",Emission,Water
+"Fatty acids, C8-10, C12-18-alkyl esters",Emission,Air
+"Fatty acids, C8-10, C12-18-alkyl esters",Emission,Ground
+"Alkenes, c10-13",Emission,Water
+"Alkenes, c10-13",Emission,Air
+"Alkenes, c10-13",Emission,Ground
+"Hydrocarbons, c4",Emission,Water
+"Hydrocarbons, c4",Emission,Air
+"Hydrocarbons, c4",Emission,Ground
+"Hydrocarbons, c4, 1,3-butadiene-free, polymd., dibutylene fraction, hydrogenated",Emission,Water
+"Hydrocarbons, c4, 1,3-butadiene-free, polymd., dibutylene fraction, hydrogenated",Emission,Air
+"Hydrocarbons, c4, 1,3-butadiene-free, polymd., dibutylene fraction, hydrogenated",Emission,Ground
+"Hydrocarbons, c4, 1,3-butadiene-free, polymd., dibutylene fraction",Emission,Water
+"Hydrocarbons, c4, 1,3-butadiene-free, polymd., dibutylene fraction",Emission,Air
+"Hydrocarbons, c4, 1,3-butadiene-free, polymd., dibutylene fraction",Emission,Ground
+"Hydrocarbons, c4, 1,3-butadiene-free, polymd., triisobutylene fraction",Emission,Water
+"Hydrocarbons, c4, 1,3-butadiene-free, polymd., triisobutylene fraction",Emission,Air
+"Hydrocarbons, c4, 1,3-butadiene-free, polymd., triisobutylene fraction",Emission,Ground
+"2-Oxetanone, 3-C12-16-alkyl-4-C13-17-alkylidene derivs.",Emission,Water
+"2-Oxetanone, 3-C12-16-alkyl-4-C13-17-alkylidene derivs.",Emission,Air
+"2-Oxetanone, 3-C12-16-alkyl-4-C13-17-alkylidene derivs.",Emission,Ground

--- a/fedelemflowlist/input/GroupsFlowables.csv
+++ b/fedelemflowlist/input/GroupsFlowables.csv
@@ -290,3 +290,10 @@ C12-14-Alkyldimethyl(ethylbenzyl) ammonium chlorides,85409-23-0,,"Quaternary amm
 C12-18-Dialkylmethylbenzyl ammonium chlorides,73049-75-9,,"Quaternary ammonium compounds, benzyldi-C12-18-alkylmethyl, chlorides",kg,https://iaspub.epa.gov/sor_internet/registry/substreg/searchandretrieve/advancedsearch/externalSearch.do?p_type=CASNO&p_value=73049-75-9,0
 C8-18 and C18-Unsaturated fatty acids ammonium salts,84776-33-0,,"Fatty acids, C8-18 and C18-unsatd., ammonium salts",kg,https://ofmpub.epa.gov/sor_internet/registry/substreg/searchandretrieve/substancesearch/search.do?details=displayDetails&selectedSubstanceId=62893,0
 Capsicum oleoresins,8023-77-6,,"Resins, oleo-, capsicum",kg,https://ofmpub.epa.gov/sor_internet/registry/substreg/searchandretrieve/substancesearch/search.do?details=displayDetails&selectedSubstanceId=16281,0
+"Fatty acids, C8-10, C12-18-alkyl esters",95912-86-0,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.096.392,1
+"Alkenes, c10-13",85535-87-1,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.079.499,1
+"Hydrocarbons, c4",87741-01-3,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.081.188,1
+"Hydrocarbons, c4, 1,3-butadiene-free, polymd., dibutylene fraction, hydrogenated",93685-78-0,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.088.709,1
+"Hydrocarbons, c4, 1,3-butadiene-free, polymd., dibutylene fraction",91052-99-2,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.084.751,1
+"Hydrocarbons, c4, 1,3-butadiene-free, polymd., triisobutylene fraction",91053-01-9,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.084.753,1
+"2-Oxetanone, 3-C12-16-alkyl-4-C13-17-alkylidene derivs.",84989-41-3,,,kg,https://echa.europa.eu/substance-information/-/substanceinfo/100.077.183; ,1


### PR DESCRIPTION
Hi! Here I am adding flowables from the [PEF](https://eplca.jrc.ec.europa.eu/EnvironmentalFootprint.html) impact method whose CAS numbers (and names) are not found in SRS EPA. Previously I addressed [PEF](https://eplca.jrc.ec.europa.eu/EnvironmentalFootprint.html) flowables that were already in the masterlist but lacking context (#147) or that were already in the SRS EPA (#148). 

There's **66** of them, **59** I added to Chemicals and **7** to Groups. Instead of using their IUPAC names I tried as much as possible to adopt a more "user-friendly" name. In doing so, I retrieved their PubChem name instead of the original flowable name from EF. In some cases PubChem did not have an entry for the EF flowable, or I could not be confident about the entry referring to exactly the same substance. For those cases, I picked the ECHA name instead, here they are:

```
Groups:
2-Oxetanone, 3-C12-16-alkyl-4-C13-17-alkylidene derivs.
Alkenes, c10-13
Hydrocarbons, c4
Hydrocarbons, c4, 1,3-butadiene-free, polymd., dibutylene fraction, hydrogenated
Hydrocarbons, c4, 1,3-butadiene-free, polymd., dibutylene fraction
Hydrocarbons, c4, 1,3-butadiene-free, polymd., triisobutylene fraction
2-Oxetanone, 3-C12-16-alkyl-4-C13-17-alkylidene derivs.
Chemicals:
2-Butene, 1,1,4,4-tetramethoxy-
Phenol, 4,5-dimethyl-2-(1-methylethyl)-
8-ethylidene-tetracyclo[4.4.0.1(2,5).1(7,10)]dodeca-3-ene
```

In these cases I did not fill Formula or Synonyms, not sure how appropriate this would be since there is no SRS entry for these flowables. I could use the PubChem synonyms, but preferred not to, since sometimes they seem to have synonyms that are not exactly synonyms but close substance matches; however, I am quite out of my comfort zone here to be able to assess whether that's the case or not.

Some of those I added under `Groups` I am quite unsecure about the classification:
```
Hydrocarbons, c4, 1,3-butadiene-free, polymd., dibutylene fraction, hydrogenated
Hydrocarbons, c4, 1,3-butadiene-free, polymd., dibutylene fraction
Hydrocarbons, c4, 1,3-butadiene-free, polymd., triisobutylene fraction
```
These three seem quite similar to each other by name.

This one also seems to be quite specific to deserve to be a Group:
```
2-Oxetanone, 3-C12-16-alkyl-4-C13-17-alkylidene derivs.
```
But I think it can include many derivates of `2-Oxetanone, 3-C12-16-alkyl-4-C13-17-alkylidene`?

Anyways, me and @ercollao @ganorris will be very happy to discuss this