### PR TITLE
Updates to use olca-schema to replace olca-ipc

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        py-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        py-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/fedelemflowlist/jsonld.py
+++ b/fedelemflowlist/jsonld.py
@@ -5,13 +5,17 @@ import math
 import uuid
 from pathlib import Path
 from typing import Optional
-
-import olca_schema as o
-import olca_schema.units as units
-import olca_schema.zipio as zipio
 import pandas as pd
-from esupy.util import make_uuid
 
+try:
+    import olca_schema as o
+    import olca_schema.units as units
+    import olca_schema.zipio as zipio
+except ImportError:
+    raise ImportError("fedelemflowlist now requires olca-schema to align with "
+                      "openLCA v2.0. Use pip install olca-schema")
+
+from esupy.util import make_uuid
 import fedelemflowlist
 from fedelemflowlist.globals import flow_list_specs
 

--- a/fedelemflowlist/jsonld.py
+++ b/fedelemflowlist/jsonld.py
@@ -6,9 +6,9 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
-import olca
-import olca.units as units
-import olca.pack as pack
+import olca_schema as o
+import olca_schema.units as units
+import olca_schema.zipio as zipio
 import pandas as pd
 from esupy.util import make_uuid
 
@@ -54,7 +54,7 @@ class _MapFlow(object):
         Creates a dictionary for an olca json file
         :return: dictionary
         """
-        flow_ref = olca.Ref()
+        flow_ref = o.Ref()
         flow_ref.name = self.name
         if self.category is not None:
             flow_ref.category_path = self.category.split('/')
@@ -136,49 +136,13 @@ class Writer(object):
         if path.exists():
             log.warning(f'File {path} already exists and will be overwritten')
             path.unlink()
-        pw = pack.Writer(path)
-        self._write_categories(pw)
-        self._write_flows(pw)
+        zw = zipio.ZipWriter(path)
+        self._write_flows(zw)
         if self.flow_mapping is not None:
-            self._write_mappings(pw)
-        pw.close()
+            self._write_mappings(zw)
+        zw.close()
 
-    def _write_categories(self, pw: pack.Writer):
-
-        root = olca.Category()
-        root.id = "f318fa60-bae9-361f-ad5a-5066a0e2a9d1"
-        root.name = "Elementary flows"
-        root.model_type = olca.ModelType.FLOW
-        self._context_uids[root.name.lower()] = root.id
-        pw.write(root)
-
-        for _, row in self.flow_list.iterrows():
-            path = row['Context']
-            if not isinstance(path, str):
-                continue
-            path = path.strip()
-            if path == '' or path.lower() in self._context_uids:
-                continue
-            parts = path.split("/")
-            parent_id = root.id
-            for i in range(0, len(parts)):
-                lpath = "/".join(parts[0:i+1]).lower()
-                uid = self._context_uids.get(lpath)
-                if uid is not None:
-                    parent_id = uid
-                    continue
-                uid = make_uuid("Flow", lpath)
-                log.info("create category %s", lpath)
-                c = olca.Category()
-                c.id = uid
-                c.name = parts[i]
-                c.category = olca.ref(olca.Category, parent_id)
-                c.model_type = olca.ModelType.FLOW
-                pw.write(c)
-                self._context_uids[lpath] = uid
-                parent_id = uid
-
-    def _write_flows(self, pw: pack.Writer):
+    def _write_flows(self, zw: zipio.ZipWriter):
         altflowlist=fedelemflowlist.get_alt_conversion()
         for _, row in self.flow_list.iterrows():
             description = "From FedElemFlowList_"+flow_list_specs['list_version']+'.'
@@ -192,7 +156,7 @@ class Writer(object):
             else:
                 description += " Not a preferred flow."
 
-            flow = olca.Flow()
+            flow = o.Flow()
             flow.description = description
             flow.id = row["Flow UUID"]
             flow.name = row["Flowable"]
@@ -201,13 +165,10 @@ class Writer(object):
             flow.version = flow_list_specs['list_version']
             flow.synonyms = row.get("Synonyms")
             flow.last_change = datetime.datetime.now().isoformat()
-            flow.flow_type = olca.FlowType.ELEMENTARY_FLOW
+            flow.flow_type = o.FlowType.ELEMENTARY_FLOW
+            flow.category = "Elementary flows/" + row['Context'].lower()
 
-            context_uid = self._context_uids.get(row['Context'].lower())
-            if context_uid is not None:
-                flow.category = olca.ref(olca.Category, context_uid)
-
-            fp = olca.FlowPropertyFactor()
+            fp = o.FlowPropertyFactor()
             fp.reference_flow_property = True
             fp.conversion_factor = 1.0
             fp.flow_property = units.property_ref(row["Unit"])
@@ -222,7 +183,7 @@ class Writer(object):
                 #create dataframe of all alternate units for this flowable
                 altunits=altflowlist[altflowlist['Flowable']==row["Flowable"]]
                 for i, alternate in altunits.iterrows():
-                    altfp = olca.FlowPropertyFactor()
+                    altfp = o.FlowPropertyFactor()
                     altfp.reference_flow_property = False
                     altfp.conversion_factor = alternate['AltUnitConversionFactor']
                     altfp.flow_property = units.property_ref(alternate["AltUnit"])
@@ -231,9 +192,9 @@ class Writer(object):
                                     alternate["AltUnit"], row["Flow UUID"])
                     else:
                         flow.flow_properties.append(altfp)
-            pw.write(flow)
+            zw.write(flow)
 
-    def _write_mappings(self, pw: pack.Writer):
+    def _write_mappings(self, zw: zipio.ZipWriter):
         maps = {}
         for i, row in self.flow_mapping.iterrows():
             me = _MapEntry(row)
@@ -244,8 +205,8 @@ class Writer(object):
             m.append(me)
 
         for source_list, entries in maps.items():
-            list_ref = olca.Ref()
-            list_ref.olca_type = 'FlowMap'
+            list_ref = o.Ref()
+            list_ref.o_type = 'FlowMap'
             list_ref.name = source_list
             mappings = []
             flow_map = {
@@ -256,4 +217,4 @@ class Writer(object):
             }
             for e in entries:
                 mappings.append(e.to_json())
-            pw.write_json(flow_map, 'flow_mappings')
+            zw.write_json(flow_map, 'flow_mappings')

--- a/fedelemflowlist/jsonld.py
+++ b/fedelemflowlist/jsonld.py
@@ -173,7 +173,7 @@ class Writer(object):
             flow.category = "Elementary flows/" + row['Context'].lower()
 
             fp = o.FlowPropertyFactor()
-            fp.reference_flow_property = True
+            fp.is_ref_flow_property = True
             fp.conversion_factor = 1.0
             fp.flow_property = units.property_ref(row["Unit"])
             if fp.flow_property is None:
@@ -188,7 +188,7 @@ class Writer(object):
                 altunits=altflowlist[altflowlist['Flowable']==row["Flowable"]]
                 for i, alternate in altunits.iterrows():
                     altfp = o.FlowPropertyFactor()
-                    altfp.reference_flow_property = False
+                    altfp.is_ref_flow_property = False
                     altfp.conversion_factor = alternate['AltUnitConversionFactor']
                     altfp.flow_property = units.property_ref(alternate["AltUnit"])
                     if altfp.flow_property is None:

--- a/format specs/FlowList.md
+++ b/format specs/FlowList.md
@@ -8,7 +8,7 @@ A Flow List is in the form of a pandas data frame with the following fields.
  CAS No | string | N | CAS number |
  Formula | string | N | Chemical formula|
  Synonyms | string | N | Flow synonyms
- Unit | string | Y  | The reference unit. uses [olca-ipc.py](https://github.com/GreenDelta/olca-ipc.py) units |
+ Unit | string | Y  | The reference unit. uses [olca-schema](https://github.com/GreenDelta/olca-schema) units |
  Class | string | Y | The flow class, e.g. `Energy` or `Chemical` |
  External Reference | string | N | E.g. a web link |
  Preferred | int |  N |   `1` for preferred*, `0` for non-preferred

--- a/format specs/Flowables.md
+++ b/format specs/Flowables.md
@@ -8,7 +8,7 @@ Flowable input files are the form of CSV data with the following fields.
  CAS No | string | N | CAS number |
  Formula | string | N | Chemical formula |
  Synonyms | string | N | Flow synonyms |
- Unit | string | Y  | The reference unit. Uses [olca-ipc.py](https://github.com/GreenDelta/olca-ipc.py) units |
+ Unit | string | Y  | The reference unit. Uses [olca-schema](https://github.com/GreenDelta/olca-schema) units |
  External Reference | string | N | Description or link to definition of flowable |
  Flowable Preferred | int | Y | Indicates whether or not flowable is preferred.* `1` for preferred, `0` for non-preferred |
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/USEPA/esupy.git@develop#egg=esupy
-olca-ipc>=0.0.12
+olca-schema>=0.0.11
 pandas>=0.22                   # Powerful data structures for data analysis, time series, and statistics.
 pip>=9                         # The PyPA recommended tool for installing Python packages.
 setuptools>=41                 # Fully-featured library designed to facilitate packaging Python projects.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
                         "flowmapping/*.*"]
         },
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     install_requires = [
         'pandas>=0.22',
         'olca-schema>=0.0.11',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     python_requires=">=3.7",
     install_requires = [
         'pandas>=0.22',
-        'olca-ipc>=0.0.12',
+        'olca-schema>=0.0.11',
         'esupy @ git+https://github.com/USEPA/esupy.git@develop#egg=esupy',
         ],
     url='https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List',

--- a/tests/test_input_files.py
+++ b/tests/test_input_files.py
@@ -80,7 +80,7 @@ class TestInputFiles(unittest.TestCase):
 
     def test_units_are_olcaunits(self):
         """Test that units are openlca reference units."""
-        import olca.units as olcaunits
+        import olca_schema.units as olcaunits
         
         for c_ in flow_list_specs["flow_classes"]:
             flowables = read_in_flowclass_file(c_, "Flowables")

--- a/tests/test_writing_jsonld.py
+++ b/tests/test_writing_jsonld.py
@@ -29,18 +29,15 @@ class TestWritingJSONLD(unittest.TestCase):
             test_extract_path = outputpath / 'test_FedElemFlowList_first100'
             flowlist_json.extractall(test_extract_path)
             flows_path = test_extract_path / 'flows'
-            categories_path = test_extract_path / 'categories'
             len_extracted_flow_files = len(list(Path(flows_path).rglob('*')))
             # Clean up
             for f in Path.iterdir(flows_path):
                 Path.unlink(flows_path / f)
-            for f in Path.iterdir(categories_path):
-                Path.unlink(categories_path / f)
             Path.rmdir(flows_path)
-            Path.rmdir(categories_path)
+            Path.unlink(test_extract_path / 'olca-schema.json')
             Path.rmdir(test_extract_path)
         except FileNotFoundError:
-            log.error(flowlist_json_file + ' not found')
+            log.error(f'{flowlist_json_file} not found')
         self.assertEqual(100, len_extracted_flow_files)
 
 


### PR DESCRIPTION
Supports the creation of the flowlist for openLCA 2.0
Drops support for python 3.7 and 3.8 (due to requirements in olca-schema)

Resolves #161 