### PR TITLE
Release v1.2.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        py-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        py-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/fedelemflowlist/globals.py
+++ b/fedelemflowlist/globals.py
@@ -53,7 +53,7 @@ log.basicConfig(level=log.INFO, format='%(levelname)s %(message)s',
                 stream=sys.stdout)
 
 flow_list_specs = {
-    "list_version": "1.1.2",
+    "list_version": "1.2.0",
     "flow_classes": ["Biological", "Chemicals", "Energy", "Geological",
                      "Groups", "Land", "Other", "Water"],
     "primary_context_classes": ["Directionality", "Environmental Media"],

--- a/format specs/FlowList.md
+++ b/format specs/FlowList.md
@@ -8,7 +8,7 @@ A Flow List is in the form of a pandas data frame with the following fields.
  CAS No | string | N | CAS number |
  Formula | string | N | Chemical formula|
  Synonyms | string | N | Flow synonyms
- Unit | string | Y  | The reference unit. uses [olca-ipc.py](https://github.com/GreenDelta/olca-ipc.py) units |
+ Unit | string | Y  | The reference unit. uses [olca-schema](https://github.com/GreenDelta/olca-schema) units |
  Class | string | Y | The flow class, e.g. `Energy` or `Chemical` |
  External Reference | string | N | E.g. a web link |
  Preferred | int |  N |   `1` for preferred*, `0` for non-preferred

--- a/format specs/Flowables.md
+++ b/format specs/Flowables.md
@@ -8,7 +8,7 @@ Flowable input files are the form of CSV data with the following fields.
  CAS No | string | N | CAS number |
  Formula | string | N | Chemical formula |
  Synonyms | string | N | Flow synonyms |
- Unit | string | Y  | The reference unit. Uses [olca-ipc.py](https://github.com/GreenDelta/olca-ipc.py) units |
+ Unit | string | Y  | The reference unit. Uses [olca-schema](https://github.com/GreenDelta/olca-schema) units |
  External Reference | string | N | Description or link to definition of flowable |
  Flowable Preferred | int | Y | Indicates whether or not flowable is preferred.* `1` for preferred, `0` for non-preferred |
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/USEPA/esupy.git#egg=esupy
+git+https://github.com/USEPA/esupy.git@develop#egg=esupy
 olca-ipc==0.0.12
 pandas>=0.22                   # Powerful data structures for data analysis, time series, and statistics.
 pip>=9                         # The PyPA recommended tool for installing Python packages.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/USEPA/esupy.git@develop#egg=esupy
+git+https://github.com/USEPA/esupy.git#egg=esupy
 olca-schema>=0.0.11
 pandas>=0.22                   # Powerful data structures for data analysis, time series, and statistics.
 pip>=9                         # The PyPA recommended tool for installing Python packages.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/USEPA/esupy.git@develop#egg=esupy
-olca-ipc==0.0.12
+olca-schema>=0.0.11
 pandas>=0.22                   # Powerful data structures for data analysis, time series, and statistics.
 pip>=9                         # The PyPA recommended tool for installing Python packages.
 setuptools>=41                 # Fully-featured library designed to facilitate packaging Python projects.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires = [
         'pandas>=0.22',
         'olca-ipc==0.0.12',
-        'esupy @ git+https://github.com/USEPA/esupy.git#egg=esupy',
+        'esupy @ git+https://github.com/USEPA/esupy.git@develop#egg=esupy',
         ],
     url='https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List',
     license='CC0',

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,10 @@ setup(
                         "flowmapping/*.*"]
         },
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     install_requires = [
         'pandas>=0.22',
-        'olca-ipc==0.0.12',
+        'olca-schema>=0.0.11',
         'esupy @ git+https://github.com/USEPA/esupy.git@develop#egg=esupy',
         ],
     url='https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='fedelemflowlist',
-    version='1.1.2',
+    version='1.2.0',
     packages=['fedelemflowlist'],
     package_dir={'fedelemflowlist': 'fedelemflowlist'},
     package_data={'fedelemflowlist': [
@@ -14,7 +14,7 @@ setup(
     install_requires = [
         'pandas>=0.22',
         'olca-schema>=0.0.11',
-        'esupy @ git+https://github.com/USEPA/esupy.git@develop#egg=esupy',
+        'esupy @ git+https://github.com/USEPA/esupy.git#egg=esupy',
         ],
     url='https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List',
     license='CC0',

--- a/tests/test_input_files.py
+++ b/tests/test_input_files.py
@@ -80,7 +80,7 @@ class TestInputFiles(unittest.TestCase):
 
     def test_units_are_olcaunits(self):
         """Test that units are openlca reference units."""
-        import olca.units as olcaunits
+        import olca_schema.units as olcaunits
         
         for c_ in flow_list_specs["flow_classes"]:
             flowables = read_in_flowclass_file(c_, "Flowables")

--- a/tests/test_writing_jsonld.py
+++ b/tests/test_writing_jsonld.py
@@ -29,18 +29,15 @@ class TestWritingJSONLD(unittest.TestCase):
             test_extract_path = outputpath / 'test_FedElemFlowList_first100'
             flowlist_json.extractall(test_extract_path)
             flows_path = test_extract_path / 'flows'
-            categories_path = test_extract_path / 'categories'
             len_extracted_flow_files = len(list(Path(flows_path).rglob('*')))
             # Clean up
             for f in Path.iterdir(flows_path):
                 Path.unlink(flows_path / f)
-            for f in Path.iterdir(categories_path):
-                Path.unlink(categories_path / f)
             Path.rmdir(flows_path)
-            Path.rmdir(categories_path)
+            Path.unlink(test_extract_path / 'olca-schema.json')
             Path.rmdir(test_extract_path)
         except FileNotFoundError:
-            log.error(flowlist_json_file + ' not found')
+            log.error(f'{flowlist_json_file} not found')
         self.assertEqual(100, len_extracted_flow_files)
 
 


### PR DESCRIPTION
- Enables support for openLCA 2.0
- Updates to use olca-schema to replace olca-ipc, deprecates Python 3.7 and 3.8 (https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List/pull/177)
- Fix error in ConversionFactor for ImpactWorld+ mapping file, resolves https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List/issues/158 (https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List/pull/160)